### PR TITLE
Replace /main paths with /Main for automatic downloads

### DIFF
--- a/RTCW-MP/qcommon/files.c
+++ b/RTCW-MP/qcommon/files.c
@@ -532,6 +532,12 @@ char *FS_BuildOSPath( const char *base, const char *game, const char *qpath ) {
 		game = fs_gamedir;
 	}
 
+	if ( !strncmp( game, "main/", 5 ) ) {
+		char *uppercaseMainFilename = game;
+		uppercaseMainFilename[0] = 'M';
+		game = uppercaseMainFilename;
+	}
+
 	Com_sprintf( temp, sizeof( temp ), "/%s/%s", game, qpath );
 	FS_ReplaceSeparators( temp );
 	Com_sprintf( ospath[toggle], sizeof( ospath[0] ), "%s%s", base, temp );

--- a/RTCW-MP/sys/sys_unix.c
+++ b/RTCW-MP/sys/sys_unix.c
@@ -178,7 +178,6 @@ char *Sys_GogPath( void )
 void Sys_SetHomeDir( const char* newHomeDir )
 {
     Q_strncpyz(homePath, newHomeDir, sizeof(homePath));
-    Q_strcat(homePath, sizeof(homePath), "/");
 }
 #endif
 

--- a/RTCW-SP/sys/sys_unix.c
+++ b/RTCW-SP/sys/sys_unix.c
@@ -179,7 +179,6 @@ char *Sys_GogPath( void )
 void Sys_SetHomeDir( const char* newHomeDir )
 {
     Q_strncpyz(homePath, newHomeDir, sizeof(homePath));
-    Q_strcat(homePath, sizeof(homePath), "/");
 }
 #endif
 


### PR DESCRIPTION
This pull request fixes a path issue where files written to the `Main` directory in the home path would fail. On tvOS and iOS automatic downloads would repeatedly download unsuccessfully, using the Simulator a crash would occur when attempting to create a `main` directory.

To reproduce this starting a game connecting to the `|ToaK| Speedy` or the `rtcwpro-testing` server would have issues. It's not very elegant, but the solution is to replace the `main` directory with the `Main` directory for path operations.

Additionally, a superfluous trailing slash was removed from the home directory.